### PR TITLE
Merge GH9 -> v0.0.1 branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lerp = "0.4"
 num = "0.4"
 
 [dev-dependencies]

--- a/src/hex/axial.rs
+++ b/src/hex/axial.rs
@@ -49,6 +49,15 @@ impl TileCoords for AxialCoords {
     fn distance(&self, other: &Self) -> isize {
         CubeCoords::from(self).distance(&CubeCoords::from(other))
     }
+
+    fn line_to(&self, other: &Self) -> Vec<Self> {
+        let cube_coords = CubeCoords::from(self).line_to(&CubeCoords::from(other));
+		let mut tiles = Vec::new();
+		for cube in cube_coords {
+			tiles.push(Self::from(cube));
+		}
+		tiles
+    }
 }
 
 

--- a/src/hex/offset.rs
+++ b/src/hex/offset.rs
@@ -53,6 +53,15 @@ impl TileCoords for OffsetCoords
     fn distance(&self, other: &Self) -> isize {
         CubeCoords::from(self).distance(&CubeCoords::from(other))
     }
+
+    fn line_to(&self, other: &Self) -> Vec<Self> {
+        let cube_coords = CubeCoords::from(self).line_to(&CubeCoords::from(other));
+		let mut tiles = Vec::new();
+		for cube in cube_coords {
+			tiles.push(Self::from(cube));
+		}
+		tiles
+    }
 }
 
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,4 +13,6 @@ pub trait TileCoords: Debug + Sized + PartialEq {
 	fn adjacent_coords(&self) -> Vec<Self>;
 
 	fn distance(&self, other: &Self) -> isize;
+
+	fn line_to(&self, other: &Self) -> Vec<Self>;
 }


### PR DESCRIPTION
* Add `line_to` method to `TileCoords` trait for getting a straight line of coordinates
* Implement for Axial, Cube, and Offset coords