### PR TITLE
Merge GH10 Coordinate Transformation

### DIFF
--- a/src/hex/axial.rs
+++ b/src/hex/axial.rs
@@ -65,6 +65,13 @@ impl TileCoords for AxialCoords {
 		let y = 3.0 / 2.0 * self.r as f32;
         (x, y)
     }
+
+    fn from_world(x: f32, y: f32) -> Self {
+		let sqrt_3 = (3 as f32).sqrt();
+		let q = (sqrt_3 / 3.0 * x - 1.0 / 3.0 * y).round() as isize;
+		let r = (2.0 / 3.0 * y).round() as isize;
+        Self{ q, r }
+    }
 }
 
 
@@ -192,6 +199,20 @@ mod tests {
 				assert_eq!(1, AxialCoords::new(1, -1).distance(&AxialCoords::splat(0)));
 				assert_eq!(2, AxialCoords::new(1, -1).distance(&AxialCoords::new(-1, 0)));
 				assert_eq!(3, AxialCoords::new(2, -1).distance(&AxialCoords::new(-1, 0)));
+			}
+
+			#[test]
+			fn from_world() {
+				let width = (3.0 as f32).sqrt();
+				let height = 2.0;
+
+				assert_eq!(AxialCoords::new(0, 0), AxialCoords::from_world(0.0, 0.0));
+				assert_eq!(AxialCoords::new(1, 0), AxialCoords::from_world(width, 0.0));
+				assert_eq!(AxialCoords::new(0, 1), AxialCoords::from_world(width * 0.5, height * 0.75));
+				assert_eq!(AxialCoords::new(-1, 1), AxialCoords::from_world(width * -0.5, height * 0.75));
+				assert_eq!(AxialCoords::new(-1, 0), AxialCoords::from_world(-width, 0.0));
+				assert_eq!(AxialCoords::new(0, -1), AxialCoords::from_world(width * -0.5, height * -0.75));
+				assert_eq!(AxialCoords::new(1, -1), AxialCoords::from_world(width * 0.5, height * -0.75));
 			}
 
 			#[test]

--- a/src/hex/cube.rs
+++ b/src/hex/cube.rs
@@ -90,6 +90,10 @@ impl TileCoords for CubeCoords {
     fn to_world(&self) -> (f32, f32) {
         AxialCoords::from(self).to_world()
     }
+
+    fn from_world(x: f32, y: f32) -> Self {
+        Self::from(AxialCoords::from_world(x, y))
+    }
 }
 
 

--- a/src/hex/offset.rs
+++ b/src/hex/offset.rs
@@ -66,6 +66,10 @@ impl TileCoords for OffsetCoords
     fn to_world(&self) -> (f32, f32) {
         AxialCoords::from(self).to_world()
     }
+
+    fn from_world(x: f32, y: f32) -> Self {
+        Self::from(AxialCoords::from_world(x, y))
+    }
 }
 
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -16,6 +16,8 @@ pub trait TileCoords: Debug + Sized + PartialEq {
 
 	fn line_to(&self, other: &Self) -> Vec<Self>;
 
+	fn from_world(x: f32, y: f32) -> Self;
+
 	/// Converts this tile coordinate into cartesian world coordinates, representing the center of
 	/// the tile.
 	fn to_world(&self) -> (f32, f32);


### PR DESCRIPTION
* Add `to_world` and `from_world` to `TileCoords` trait. `to_world` converts a tile coordinate object to cartesian coords, and `from_world` converts a set of world coordinates to tile coordinates.
* Implement `to_world` and `from_world` for `AxialCoords`
* Implement `to_world` and `from_world` for Cube and Offset coords via coordinate to axial coords and back. This could be improved by implementing their own algorithms